### PR TITLE
Bump svelte to `5.0.0-next.90`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "!dist/**/*.spec.*"
   ],
   "peerDependencies": {
-    "svelte": "^5.0.0-next.57"
+    "svelte": "^5.0.0-next.89"
   },
   "devDependencies": {
     "@playwright/test": "1.42.1",
@@ -63,7 +63,7 @@
     "prettier": "3.2.5",
     "prettier-plugin-svelte": "3.2.2",
     "publint": "0.2.7",
-    "svelte": "5.0.0-next.82",
+    "svelte": "5.0.0-next.90",
     "svelte-check": "3.6.8",
     "tslib": "2.6.2",
     "typescript": "5.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,13 +13,13 @@ devDependencies:
     version: 3.1.1(@sveltejs/kit@2.5.4)
   '@sveltejs/kit':
     specifier: 2.5.4
-    version: 2.5.4(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.82)(vite@5.2.7)
+    version: 2.5.4(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.90)(vite@5.2.7)
   '@sveltejs/package':
     specifier: 2.3.0
-    version: 2.3.0(svelte@5.0.0-next.82)(typescript@5.4.3)
+    version: 2.3.0(svelte@5.0.0-next.90)(typescript@5.4.3)
   '@sveltejs/vite-plugin-svelte':
     specifier: 3.0.2
-    version: 3.0.2(svelte@5.0.0-next.82)(vite@5.2.7)
+    version: 3.0.2(svelte@5.0.0-next.90)(vite@5.2.7)
   '@types/eslint':
     specifier: 8.56.6
     version: 8.56.6
@@ -40,7 +40,7 @@ devDependencies:
     version: 5.1.3(@types/eslint@8.56.6)(eslint-config-prettier@9.1.0)(eslint@8.57.0)(prettier@3.2.5)
   eslint-plugin-svelte:
     specifier: 2.35.1
-    version: 2.35.1(eslint@8.57.0)(svelte@5.0.0-next.82)
+    version: 2.35.1(eslint@8.57.0)(svelte@5.0.0-next.90)
   jsdom:
     specifier: 24.0.0
     version: 24.0.0
@@ -49,16 +49,16 @@ devDependencies:
     version: 3.2.5
   prettier-plugin-svelte:
     specifier: 3.2.2
-    version: 3.2.2(prettier@3.2.5)(svelte@5.0.0-next.82)
+    version: 3.2.2(prettier@3.2.5)(svelte@5.0.0-next.90)
   publint:
     specifier: 0.2.7
     version: 0.2.7
   svelte:
-    specifier: 5.0.0-next.82
-    version: 5.0.0-next.82
+    specifier: 5.0.0-next.90
+    version: 5.0.0-next.90
   svelte-check:
     specifier: 3.6.8
-    version: 3.6.8(postcss@8.4.34)(svelte@5.0.0-next.82)
+    version: 3.6.8(postcss@8.4.34)(svelte@5.0.0-next.90)
   tslib:
     specifier: 2.6.2
     version: 2.6.2
@@ -559,11 +559,11 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
     dependencies:
-      '@sveltejs/kit': 2.5.4(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.82)(vite@5.2.7)
+      '@sveltejs/kit': 2.5.4(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.90)(vite@5.2.7)
       import-meta-resolve: 4.0.0
     dev: true
 
-  /@sveltejs/kit@2.5.4(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.82)(vite@5.2.7):
+  /@sveltejs/kit@2.5.4(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.90)(vite@5.2.7):
     resolution: {integrity: sha512-eDxK2d4EGzk99QsZNoPXe7jlzA5EGqfcCpUwZ912bhnalsZ2ZsG5wGRthkydupVjYyqdmzEanVKFhLxU2vkPSQ==}
     engines: {node: '>=18.13'}
     hasBin: true
@@ -573,7 +573,7 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.3
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@5.0.0-next.82)(vite@5.2.7)
+      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@5.0.0-next.90)(vite@5.2.7)
       '@types/cookie': 0.6.0
       cookie: 0.6.0
       devalue: 4.3.2
@@ -585,12 +585,12 @@ packages:
       sade: 1.8.1
       set-cookie-parser: 2.6.0
       sirv: 2.0.4
-      svelte: 5.0.0-next.82
+      svelte: 5.0.0-next.90
       tiny-glob: 0.2.9
       vite: 5.2.7
     dev: true
 
-  /@sveltejs/package@2.3.0(svelte@5.0.0-next.82)(typescript@5.4.3):
+  /@sveltejs/package@2.3.0(svelte@5.0.0-next.90)(typescript@5.4.3):
     resolution: {integrity: sha512-wmtwEfi3gQnmtotAjygRHR6cmLfpblQl1dU764f3N2I5DPe34llFs44bHOYcuk91Bp2sSq6bWUmNwxGlYCchOA==}
     engines: {node: ^16.14 || >=18}
     hasBin: true
@@ -601,13 +601,13 @@ packages:
       kleur: 4.1.5
       sade: 1.8.1
       semver: 7.6.0
-      svelte: 5.0.0-next.82
-      svelte2tsx: 0.7.0(svelte@5.0.0-next.82)(typescript@5.4.3)
+      svelte: 5.0.0-next.90
+      svelte2tsx: 0.7.0(svelte@5.0.0-next.90)(typescript@5.4.3)
     transitivePeerDependencies:
       - typescript
     dev: true
 
-  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.82)(vite@5.2.7):
+  /@sveltejs/vite-plugin-svelte-inspector@2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.90)(vite@5.2.7):
     resolution: {integrity: sha512-gjr9ZFg1BSlIpfZ4PRewigrvYmHWbDrq2uvvPB1AmTWKuM+dI1JXQSUu2pIrYLb/QncyiIGkFDFKTwJ0XqQZZg==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
@@ -615,28 +615,28 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@5.0.0-next.82)(vite@5.2.7)
+      '@sveltejs/vite-plugin-svelte': 3.0.2(svelte@5.0.0-next.90)(vite@5.2.7)
       debug: 4.3.4
-      svelte: 5.0.0-next.82
+      svelte: 5.0.0-next.90
       vite: 5.2.7
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@sveltejs/vite-plugin-svelte@3.0.2(svelte@5.0.0-next.82)(vite@5.2.7):
+  /@sveltejs/vite-plugin-svelte@3.0.2(svelte@5.0.0-next.90)(vite@5.2.7):
     resolution: {integrity: sha512-MpmF/cju2HqUls50WyTHQBZUV3ovV/Uk8k66AN2gwHogNAG8wnW8xtZDhzNBsFJJuvmq1qnzA5kE7YfMJNFv2Q==}
     engines: {node: ^18.0.0 || >=20}
     peerDependencies:
       svelte: ^4.0.0 || ^5.0.0-next.0
       vite: ^5.0.0
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.82)(vite@5.2.7)
+      '@sveltejs/vite-plugin-svelte-inspector': 2.0.0(@sveltejs/vite-plugin-svelte@3.0.2)(svelte@5.0.0-next.90)(vite@5.2.7)
       debug: 4.3.4
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.7
-      svelte: 5.0.0-next.82
-      svelte-hmr: 0.15.3(svelte@5.0.0-next.82)
+      svelte: 5.0.0-next.90
+      svelte-hmr: 0.15.3(svelte@5.0.0-next.90)
       vite: 5.2.7
       vitefu: 0.2.5(vite@5.2.7)
     transitivePeerDependencies:
@@ -1288,7 +1288,7 @@ packages:
       synckit: 0.8.8
     dev: true
 
-  /eslint-plugin-svelte@2.35.1(eslint@8.57.0)(svelte@5.0.0-next.82):
+  /eslint-plugin-svelte@2.35.1(eslint@8.57.0)(svelte@5.0.0-next.90):
     resolution: {integrity: sha512-IF8TpLnROSGy98Z3NrsKXWDSCbNY2ReHDcrYTuXZMbfX7VmESISR78TWgO9zdg4Dht1X8coub5jKwHzP0ExRug==}
     engines: {node: ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1310,8 +1310,8 @@ packages:
       postcss-safe-parser: 6.0.0(postcss@8.4.34)
       postcss-selector-parser: 6.0.15
       semver: 7.6.0
-      svelte: 5.0.0-next.82
-      svelte-eslint-parser: 0.33.1(svelte@5.0.0-next.82)
+      svelte: 5.0.0-next.90
+      svelte-eslint-parser: 0.33.1(svelte@5.0.0-next.90)
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -2243,14 +2243,14 @@ packages:
       fast-diff: 1.3.0
     dev: true
 
-  /prettier-plugin-svelte@3.2.2(prettier@3.2.5)(svelte@5.0.0-next.82):
+  /prettier-plugin-svelte@3.2.2(prettier@3.2.5)(svelte@5.0.0-next.90):
     resolution: {integrity: sha512-ZzzE/wMuf48/1+Lf2Ffko0uDa6pyCfgHV6+uAhtg2U0AAXGrhCSW88vEJNAkAxW5qyrFY1y1zZ4J8TgHrjW++Q==}
     peerDependencies:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
     dependencies:
       prettier: 3.2.5
-      svelte: 5.0.0-next.82
+      svelte: 5.0.0-next.90
     dev: true
 
   /prettier@3.2.5:
@@ -2508,7 +2508,7 @@ packages:
       has-flag: 4.0.0
     dev: true
 
-  /svelte-check@3.6.8(postcss@8.4.34)(svelte@5.0.0-next.82):
+  /svelte-check@3.6.8(postcss@8.4.34)(svelte@5.0.0-next.90):
     resolution: {integrity: sha512-rhXU7YCDtL+lq2gCqfJDXKTxJfSsCgcd08d7VWBFxTw6IWIbMWSaASbAOD3N0VV9TYSSLUqEBiratLd8WxAJJA==}
     hasBin: true
     peerDependencies:
@@ -2520,8 +2520,8 @@ packages:
       import-fresh: 3.3.0
       picocolors: 1.0.0
       sade: 1.8.1
-      svelte: 5.0.0-next.82
-      svelte-preprocess: 5.1.3(postcss@8.4.34)(svelte@5.0.0-next.82)(typescript@5.4.3)
+      svelte: 5.0.0-next.90
+      svelte-preprocess: 5.1.3(postcss@8.4.34)(svelte@5.0.0-next.90)(typescript@5.4.3)
       typescript: 5.4.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -2535,7 +2535,7 @@ packages:
       - sugarss
     dev: true
 
-  /svelte-eslint-parser@0.33.1(svelte@5.0.0-next.82):
+  /svelte-eslint-parser@0.33.1(svelte@5.0.0-next.90):
     resolution: {integrity: sha512-vo7xPGTlKBGdLH8T5L64FipvTrqv3OQRx9d2z5X05KKZDlF4rQk8KViZO4flKERY+5BiVdOh7zZ7JGJWo5P0uA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2549,19 +2549,19 @@ packages:
       espree: 9.6.1
       postcss: 8.4.35
       postcss-scss: 4.0.9(postcss@8.4.35)
-      svelte: 5.0.0-next.82
+      svelte: 5.0.0-next.90
     dev: true
 
-  /svelte-hmr@0.15.3(svelte@5.0.0-next.82):
+  /svelte-hmr@0.15.3(svelte@5.0.0-next.90):
     resolution: {integrity: sha512-41snaPswvSf8TJUhlkoJBekRrABDXDMdpNpT2tfHIv4JuhgvHqLMhEPGtaQn0BmbNSTkuz2Ed20DF2eHw0SmBQ==}
     engines: {node: ^12.20 || ^14.13.1 || >= 16}
     peerDependencies:
       svelte: ^3.19.0 || ^4.0.0
     dependencies:
-      svelte: 5.0.0-next.82
+      svelte: 5.0.0-next.90
     dev: true
 
-  /svelte-preprocess@5.1.3(postcss@8.4.34)(svelte@5.0.0-next.82)(typescript@5.4.3):
+  /svelte-preprocess@5.1.3(postcss@8.4.34)(svelte@5.0.0-next.90)(typescript@5.4.3):
     resolution: {integrity: sha512-xxAkmxGHT+J/GourS5mVJeOXZzne1FR5ljeOUAMXUkfEhkLEllRreXpbl3dIYJlcJRfL1LO1uIAPpBpBfiqGPw==}
     engines: {node: '>= 16.0.0', pnpm: ^8.0.0}
     requiresBuild: true
@@ -2605,11 +2605,11 @@ packages:
       postcss: 8.4.34
       sorcery: 0.11.0
       strip-indent: 3.0.0
-      svelte: 5.0.0-next.82
+      svelte: 5.0.0-next.90
       typescript: 5.4.3
     dev: true
 
-  /svelte2tsx@0.7.0(svelte@5.0.0-next.82)(typescript@5.4.3):
+  /svelte2tsx@0.7.0(svelte@5.0.0-next.90)(typescript@5.4.3):
     resolution: {integrity: sha512-qAelcydnmuiDvD1HsrWi23RWx24RZTKRv6n4JaGC/pkoJfbLkJPQT2wa1qN0ZyfKTNLSyoj2FW9z62l/AUzUNA==}
     peerDependencies:
       svelte: ^3.55 || ^4.0.0-next.0 || ^4.0 || ^5.0.0-next.0
@@ -2617,12 +2617,12 @@ packages:
     dependencies:
       dedent-js: 1.0.1
       pascal-case: 3.1.2
-      svelte: 5.0.0-next.82
+      svelte: 5.0.0-next.90
       typescript: 5.4.3
     dev: true
 
-  /svelte@5.0.0-next.82:
-    resolution: {integrity: sha512-iP2O+As6oM6X21zhaY6wbYGPEEmoubP2i7dhuU85ih1ZJYpyk67cE4SYzTm+X/NqW3dVc36jo/Zf0BOxPXVnfA==}
+  /svelte@5.0.0-next.90:
+    resolution: {integrity: sha512-qx5shVIRQ9b3VPgj/rim16dWi3md8B8HjHSO5p6RCSg/GP00f9CVUoUtnuCpT4f7ZnBJa/IG3v2rgW9Zn9zEqg==}
     engines: {node: '>=18'}
     dependencies:
       '@ampproject/remapping': 2.2.1

--- a/src/routes/+layout.ts
+++ b/src/routes/+layout.ts
@@ -1,1 +1,1 @@
-export const ssr = false;
+export const ssr = true;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -20,25 +20,27 @@
         <span>extra large 2</span>
       {/snippet}
 
-      <Breakpoints queries={DEFAULT_BREAKPOINT_SIZES} content={{ xl2 }}>
-        {#snippet sm()}
-          <span>small</span>
-        {/snippet}
-        {#snippet md()}
-          <span>medium</span>
-        {/snippet}
-        {#snippet lg()}
-          <span>large</span>
-        {/snippet}
-        {#snippet xl()}
-          <span>extra large</span>
-        {/snippet}
-        <span>unknown</span>
-      </Breakpoints>
+      <span data-test-id="current-match">
+        <Breakpoints queries={DEFAULT_BREAKPOINT_SIZES} content={{ xl2 }}>
+          {#snippet sm()}
+            small
+          {/snippet}
+          {#snippet md()}
+            medium
+          {/snippet}
+          {#snippet lg()}
+            large
+          {/snippet}
+          {#snippet xl()}
+            extra large
+          {/snippet}
+          unknown
+        </Breakpoints>
+      </span>
     </strong></h2>
 
     <Breakpoints queries={DEFAULT_BREAKPOINT_SIZES} let:$matches>
-      <p>Here are all matching queries from binding to the store: {$matches.join(', ')}</p>
+      <p>Here are all matching queries from binding to the store: <span data-test-id="matches-store">{$matches.join(', ')}</span></p>
     </Breakpoints>
 
     <Breakpoints queries={{

--- a/tests/index_test.ts
+++ b/tests/index_test.ts
@@ -18,3 +18,27 @@ test('index page breakpoints respond to viewport changes', async ({ page }) => {
     ).toBeVisible();
   }
 });
+
+test('store of current matches functions as expected', async ({ page }) => {
+  await page.goto('/');
+
+  await page.setViewportSize({ width: 400, height: 600 });
+
+  await expect(page.locator('[data-test-id="matches-store"]')).toBeVisible();
+
+  expect(
+    await page.locator('[data-test-id="matches-store"]').textContent()
+  ).toEqual('sm');
+
+  await page.setViewportSize({ width: 800, height: 600 });
+
+  expect(
+    await page.locator('[data-test-id="matches-store"]').textContent()
+  ).toEqual('sm, md');
+
+  await page.setViewportSize({ width: 1050, height: 600 });
+
+  expect(
+    await page.locator('[data-test-id="matches-store"]').textContent()
+  ).toEqual('sm, md, lg');
+});


### PR DESCRIPTION
- Bump Svelte to v`5.0.0-next.90`
- Re-enable SSR (prev disabled due to hydration mismatches w/ whitespace)
- Add tests to cover `matches` readable usage when binding directly w/ `let:` from slot
